### PR TITLE
Rename cmpspec to something more intuitive like comparator, cmp_class…

### DIFF
--- a/changelog.d/435.change.rst
+++ b/changelog.d/435.change.rst
@@ -1,6 +1,6 @@
-Added ``cmpspec`` to ``Attribute`` and ``attr.ib()`` (`#435 <https://github.com/python-attrs/attrs/issues/435>`_).
+Added ``comparator`` to ``Attribute`` and ``attr.ib()`` (`#435 <https://github.com/python-attrs/attrs/issues/435>`_).
 
-``CmpSpec`` must be a class that wraps a value and implements equality and ordering methods.
+``comparator`` must be a class that wraps a value and implements equality and ordering methods.
 
 This change was motivated by the fact that some popular packages (``pandas dataframes``,
 ``numpy arrays``) overload equality and ordering methods to return values that are not boolean,
@@ -14,5 +14,5 @@ This change will also allow users to customize ``Attribute`` comparison in more
 intuitive scenarios, e.g. *case insensitive strings*, or simply using a sort-like *key*
 as requested in (`#624 <https://github.com/python-attrs/attrs/issues/624>`_).
 
-Finally, we provide a few off-the-shelf ``CmpSpec`` classes in the package ``attr.cmpspec``
+Finally, we provide a few off-the-shelf ``comparator`` classes in the package ``attr.comparators``
 that users can use in the most common cases, or use as template to implement their own.

--- a/src/attr/__init__.pyi
+++ b/src/attr/__init__.pyi
@@ -113,7 +113,7 @@ def attrib(
     kw_only: bool = ...,
     eq: Optional[bool] = ...,
     order: Optional[bool] = ...,
-    cmpspec: Optional[type] = ...,
+    comparator: Optional[type] = ...,
 ) -> Any: ...
 
 # This form catches an explicit None or no default and infers the type from the other arguments.
@@ -132,7 +132,7 @@ def attrib(
     kw_only: bool = ...,
     eq: Optional[bool] = ...,
     order: Optional[bool] = ...,
-    cmpspec: Optional[type] = ...,
+    comparator: Optional[type] = ...,
 ) -> _T: ...
 
 # This form catches an explicit default argument.
@@ -151,7 +151,7 @@ def attrib(
     kw_only: bool = ...,
     eq: Optional[bool] = ...,
     order: Optional[bool] = ...,
-    cmpspec: Optional[type] = ...,
+    comparator: Optional[type] = ...,
 ) -> _T: ...
 
 # This form covers type=non-Type: e.g. forward references (str), Any
@@ -170,7 +170,7 @@ def attrib(
     kw_only: bool = ...,
     eq: Optional[bool] = ...,
     order: Optional[bool] = ...,
-    cmpspec: Optional[type] = ...,
+    comparator: Optional[type] = ...,
 ) -> Any: ...
 @overload
 def attrs(

--- a/src/attr/_make.py
+++ b/src/attr/_make.py
@@ -109,7 +109,7 @@ def attrib(
     kw_only=False,
     eq=None,
     order=None,
-    cmpspec=None,
+    comparator=None,
 ):
     """
     Create a new attribute on a class.
@@ -201,8 +201,8 @@ def attrib(
         in the generated ``__init__`` (if ``init`` is ``False``, this
         parameter is ignored).
 
-    :param cmpspec: Class used to compare attribute. It must be initializable
-        with the value of the attribute, and implement equality
+    :param comparator: Class used to compare attribute. It must be
+        initializable with the value of the attribute, and implement equality
         (e.g. ``__eq__``) and ordering (e.g. ``__lt__'') functions.
 
     .. versionadded:: 15.2.0 *convert*
@@ -221,7 +221,7 @@ def attrib(
     .. versionchanged:: 19.2.0 *repr* also accepts a custom callable.
     .. deprecated:: 19.2.0 *cmp* Removal on or after 2021-06-01.
     .. versionadded:: 19.2.0 *eq* and *order*
-    .. versionadded:: 20.1.0.dev0_botant *cmpspec*
+    .. versionadded:: 20.1.0.dev0_botant *comparator*
     """
     eq, order = _determine_eq_order(cmp, eq, order)
 
@@ -256,7 +256,7 @@ def attrib(
         kw_only=kw_only,
         eq=eq,
         order=order,
-        cmpspec=cmpspec,
+        comparator=comparator,
     )
 
 
@@ -1069,9 +1069,9 @@ def _attrs_to_cmp_tuple(obj, attrs):
        eq and order methods.
     """
     return tuple(
-        cmpspec(value) if cmpspec else value
-        for value, cmpspec in (
-            (getattr(obj, a.name), a.cmpspec) for a in attrs
+        comparator(value) if comparator else value
+        for value, comparator in (
+            (getattr(obj, a.name), a.comparator) for a in attrs
         )
     )
 
@@ -1229,11 +1229,11 @@ def _make_eq(cls, attrs):
         lines.append("    return  (")
         others = ["    ) == ("]
         for a in attrs:
-            if a.cmpspec:
+            if a.comparator:
                 cmp_name = "_%s_comparator" % (a.name,)
                 # Add the cmp class to the global namespace of the evaluated
                 # function, since local does not work in all python versions.
-                global_vars[cmp_name] = a.cmpspec
+                global_vars[cmp_name] = a.comparator
                 lines.append("        %s(self.%s)," % (cmp_name, a.name,))
                 others.append("        %s(other.%s)," % (cmp_name, a.name,))
             else:
@@ -1819,7 +1819,7 @@ class Attribute(object):
         "repr",
         "eq",
         "order",
-        "cmpspec",
+        "comparator",
         "hash",
         "init",
         "metadata",
@@ -1843,7 +1843,7 @@ class Attribute(object):
         kw_only=False,
         eq=None,
         order=None,
-        cmpspec=None,
+        comparator=None,
     ):
         eq, order = _determine_eq_order(cmp, eq, order)
 
@@ -1858,7 +1858,7 @@ class Attribute(object):
         bound_setattr("repr", repr)
         bound_setattr("eq", eq)
         bound_setattr("order", order)
-        bound_setattr("cmpspec", cmpspec)
+        bound_setattr("comparator", comparator)
         bound_setattr("hash", hash)
         bound_setattr("init", init)
         bound_setattr("converter", converter)
@@ -1966,7 +1966,7 @@ _a = [
         order=False,
         hash=(name != "metadata"),
         init=True,
-        cmpspec=None,
+        comparator=None,
     )
     for name in Attribute.__slots__
 ]
@@ -1992,7 +1992,7 @@ class _CountingAttr(object):
         "repr",
         "eq",
         "order",
-        "cmpspec",
+        "comparator",
         "hash",
         "init",
         "metadata",
@@ -2013,7 +2013,7 @@ class _CountingAttr(object):
             kw_only=False,
             eq=True,
             order=False,
-            cmpspec=None,
+            comparator=None,
         )
         for name in (
             "counter",
@@ -2036,7 +2036,7 @@ class _CountingAttr(object):
             kw_only=False,
             eq=True,
             order=False,
-            cmpspec=None,
+            comparator=None,
         ),
     )
     cls_counter = 0
@@ -2055,7 +2055,7 @@ class _CountingAttr(object):
         kw_only,
         eq,
         order,
-        cmpspec,
+        comparator,
     ):
         _CountingAttr.cls_counter += 1
         self.counter = _CountingAttr.cls_counter
@@ -2068,7 +2068,7 @@ class _CountingAttr(object):
         self.repr = repr
         self.eq = eq
         self.order = order
-        self.cmpspec = cmpspec
+        self.comparator = comparator
         self.hash = hash
         self.init = init
         self.converter = converter

--- a/src/attr/_make.py
+++ b/src/attr/_make.py
@@ -1210,6 +1210,9 @@ def __ne__(self, other):
 
 
 def _make_eq(cls, attrs):
+    """
+    Create equality methods.
+    """
     attrs = [a for a in attrs if a.eq]
 
     unique_filename = _generate_unique_filename(cls, "eq")
@@ -1218,6 +1221,7 @@ def _make_eq(cls, attrs):
         "    if other.__class__ is not self.__class__:",
         "        return NotImplemented",
     ]
+
     # We can't just do a big self.x = other.x and... clause due to
     # irregularities like nan == nan is false but (nan,) == (nan,) is true.
     global_vars = {}
@@ -1226,9 +1230,9 @@ def _make_eq(cls, attrs):
         others = ["    ) == ("]
         for a in attrs:
             if a.cmpspec:
-                cmp_name = "_%s_cmpspec" % (a.name,)
+                cmp_name = "_%s_comparator" % (a.name,)
                 # Add the cmp class to the global namespace of the evaluated
-                # fucntion, since local does not work in all python versions.
+                # function, since local does not work in all python versions.
                 global_vars[cmp_name] = a.cmpspec
                 lines.append("        %s(self.%s)," % (cmp_name, a.name,))
                 others.append("        %s(other.%s)," % (cmp_name, a.name,))

--- a/tests/test_cmp.py
+++ b/tests/test_cmp.py
@@ -54,9 +54,9 @@ class ObjWithoutTruthValue(object):
         return (obj < other).value
 
 
-class TestCmpSpec(object):
+class TestComparator(object):
     """
-    Tests for equality and ordering when a CompSpec object is specified.
+    Tests for equality and ordering when a comparator object is specified.
     """
 
     @pytest.mark.parametrize("cls", [EqC, EqCSlots])
@@ -85,9 +85,9 @@ class TestCmpSpec(object):
             cls(ObjWithoutTruthValue(1), 2) >= cls(ObjWithoutTruthValue(2), 2)
 
     @given(booleans())
-    def test_cmpspec(self, slots):
+    def test_comparator(self, slots):
         """
-        Test for equality and ordering methods when attribute has cmpspec.
+        Test for equality and ordering methods when attribute has comparator.
         """
         _DCmp = make_class("_DCmp", {"value": attr.ib()}, eq=False)
         _DCmp.__eq__ = lambda obj, other: ObjWithoutTruthValue.is_equal(
@@ -99,7 +99,7 @@ class TestCmpSpec(object):
         _DCmp = functools.total_ordering(_DCmp)
 
         _D = make_class(
-            "_D", {"a": attr.ib(cmpspec=_DCmp), "b": attr.ib()}, slots=slots
+            "_D", {"a": attr.ib(comparator=_DCmp), "b": attr.ib()}, slots=slots
         )
 
         assert _D(ObjWithoutTruthValue(1), 2) == _D(ObjWithoutTruthValue(1), 2)

--- a/tests/test_make.py
+++ b/tests/test_make.py
@@ -218,7 +218,7 @@ class TestTransformAttrs(object):
             "No mandatory attributes allowed after an attribute with a "
             "default value or factory.  Attribute in question: Attribute"
             "(name='y', default=NOTHING, validator=None, repr=True, "
-            "eq=True, order=True, cmpspec=None, hash=None, init=True, "
+            "eq=True, order=True, comparator=None, hash=None, init=True, "
             "metadata=mappingproxy({}), type=None, converter=None, "
             "kw_only=False)",
         ) == e.value.args


### PR DESCRIPTION
* ``cmpspec``, ``CmpSpec``: universally hated
* ``comparator``, ``Comparator``: not exactly a word that is used outside electronics, but rhymes with ``validator``
* ``cmp_class``, ``cmp_key``
???